### PR TITLE
Disable routing through primary interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-aws-k8s-agent
-aws-cni
-verify-aws
-verify-network
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y iproute2 && \
+    apt-get install -y iptables
+
+COPY . /app/
+
+ENTRYPOINT /app/install-aws.sh
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+This fork fixes routing issues for pods with IP addresses on secondary ENIs.
+
+The proposal document below makes an assumption that the traffic for secondary ENIs
+always arrives on primary ENI, but that does not seem to be the case.
+
+## Mac OS X
+
+### Install Go and tools
+
+```
+brew install go
+brew install dep
+```
+
+### Build and push the image
+Dev version (dev-$DATE-$USER):
+```
+make release
+```
+
+Release version:
+```
+make release version='0.1.4-???'
+```
+
 # amazon-vpc-cni-k8s
 Networking plugin for pod networking in [Kubernetes](https://kubernetes.io/) using [Elastic Network Interfaces](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html) on AWS.
 

--- a/ipamd/datastore/data_store.go
+++ b/ipamd/datastore/data_store.go
@@ -20,7 +20,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi"
 )
 
 const (

--- a/ipamd/datastore/data_store_test.go
+++ b/ipamd/datastore/data_store_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/ipamd/introspect.go
+++ b/ipamd/introspect.go
@@ -22,7 +22,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/utils"
 )
 
 const (

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"github.com/aws/amazon-vpc-cni-k8s/ipamd/datastore"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
+	"github.com/transferwise/amazon-vpc-cni-k8s/ipamd/datastore"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/awsutils"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/networkutils"
 )
 
 // Package ipamd is a long running daemon which manages a warn-pool of available IP addresses.

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -14,7 +14,6 @@
 package ipamd
 
 import (
-	"net"
 	"strings"
 	"time"
 
@@ -86,20 +85,6 @@ func (c *IPAMContext) nodeInit() error {
 	if err != nil {
 		log.Error("Failed to retrive ENI info")
 		return errors.New("ipamd init: failed to retrieve attached ENIs info")
-	}
-
-	_, vpcCIDR, err := net.ParseCIDR(c.awsClient.GetVPCIPv4CIDR())
-	if err != nil {
-		log.Error("Failed to parse VPC IPv4 CIDR", err.Error())
-		return errors.Wrap(err, "ipamd init: failed to retrieve VPC CIDR")
-	}
-
-	primaryIP := net.ParseIP(c.awsClient.GetLocalIPv4())
-
-	err = c.networkClient.SetupHostNetwork(vpcCIDR, &primaryIP)
-	if err != nil {
-		log.Error("Failed to setup host network", err)
-		return errors.Wrap(err, "ipamd init: failed to setup host network")
 	}
 
 	c.dataStore = datastore.NewDataStore()

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 	//"time"
 
-	"github.com/aws/amazon-vpc-cni-k8s/ipamd/datastore"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/ipamd/datastore"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/awsutils"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/awsutils/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/networkutils/mocks"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/ipamd/rpc_handler.go
+++ b/ipamd/rpc_handler.go
@@ -18,15 +18,15 @@ import (
 
 	"github.com/pkg/errors"
 
-	pb "github.com/aws/amazon-vpc-cni-k8s/rpc"
+	pb "github.com/transferwise/amazon-vpc-cni-k8s/rpc"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
 	log "github.com/cihub/seelog"
 
-	"github.com/aws/amazon-vpc-cni-k8s/ipamd/datastore"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/transferwise/amazon-vpc-cni-k8s/ipamd/datastore"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/logger"
 
-	"github.com/aws/amazon-vpc-cni-k8s/ipamd"
+	"github.com/transferwise/amazon-vpc-cni-k8s/ipamd"
 	log "github.com/cihub/seelog"
 )
 

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -22,9 +22,9 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2metadata"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2wrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/resourcegroupstaggingapiwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ec2metadata"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ec2wrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/resourcegroupstaggingapiwrapper"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2metadata/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2wrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/resourcegroupstaggingapiwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ec2metadata/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ec2wrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/resourcegroupstaggingapiwrapper/mocks"
 )
 
 const (

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -20,7 +20,7 @@ package mock_awsutils
 import (
 	reflect "reflect"
 
-	awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
+	awsutils "github.com/transferwise/amazon-vpc-cni-k8s/pkg/awsutils"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
 )

--- a/pkg/k8sapi/k8sapi.go
+++ b/pkg/k8sapi/k8sapi.go
@@ -17,8 +17,8 @@ import (
 	"encoding/json"
 	"k8s.io/kubernetes/pkg/api"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/httpwrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ioutilwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/httpwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ioutilwrapper"
 	"github.com/pkg/errors"
 
 	log "github.com/cihub/seelog"

--- a/pkg/k8sapi/k8sapi_test.go
+++ b/pkg/k8sapi/k8sapi_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/httpwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ioutilwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/httpwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ioutilwrapper/mocks"
 )
 
 const (

--- a/pkg/k8sapi/mocks/k8sapi_mocks.go
+++ b/pkg/k8sapi/mocks/k8sapi_mocks.go
@@ -20,7 +20,7 @@ package mock_k8sapi
 import (
 	reflect "reflect"
 
-	k8sapi "github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	k8sapi "github.com/transferwise/amazon-vpc-cni-k8s/pkg/k8sapi"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -25,8 +25,8 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/nswrapper"
 )
 
 const (

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	mocks_ip "github.com/aws/amazon-vpc-cni-k8s/pkg/ipwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mock_netlink"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper/mocks"
+	mocks_ip "github.com/transferwise/amazon-vpc-cni-k8s/pkg/ipwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mock_netlink"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/nswrapper/mocks"
 )
 
 const (

--- a/pkg/rpcwrapper/client.go
+++ b/pkg/rpcwrapper/client.go
@@ -14,7 +14,7 @@
 package rpcwrapper
 
 import (
-	"github.com/aws/amazon-vpc-cni-k8s/rpc"
+	"github.com/transferwise/amazon-vpc-cni-k8s/rpc"
 	grpc "google.golang.org/grpc"
 )
 

--- a/pkg/rpcwrapper/mocks/rpcwrapper_mocks.go
+++ b/pkg/rpcwrapper/mocks/rpcwrapper_mocks.go
@@ -20,7 +20,7 @@ package mock_rpcwrapper
 import (
 	reflect "reflect"
 
-	rpc "github.com/aws/amazon-vpc-cni-k8s/rpc"
+	rpc "github.com/transferwise/amazon-vpc-cni-k8s/rpc"
 	gomock "github.com/golang/mock/gomock"
 	"google.golang.org/grpc"
 )

--- a/pkg/utils/ttime/mocks/time_mocks.go
+++ b/pkg/utils/ttime/mocks/time_mocks.go
@@ -21,7 +21,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	ttime "github.com/aws/amazon-vpc-cni-k8s/pkg/utils/ttime"
+	ttime "github.com/transferwise/amazon-vpc-cni-k8s/pkg/utils/ttime"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/ttime"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/utils/ttime"
 )
 
 func DefaultIfBlank(str string, default_value string) string {

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -34,11 +34,11 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	cniSpecVersion "github.com/containernetworking/cni/pkg/version"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/grpcwrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/rpcwrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/typeswrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/plugins/routed-eni/driver"
-	pb "github.com/aws/amazon-vpc-cni-k8s/rpc"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/grpcwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/rpcwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/typeswrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/plugins/routed-eni/driver"
+	pb "github.com/transferwise/amazon-vpc-cni-k8s/rpc"
 )
 
 const (

--- a/plugins/routed-eni/cni_test.go
+++ b/plugins/routed-eni/cni_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/grpcwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/rpcwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/typeswrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/plugins/routed-eni/driver/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/rpc"
-	"github.com/aws/amazon-vpc-cni-k8s/rpc/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/grpcwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/rpcwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/typeswrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/plugins/routed-eni/driver/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/rpc"
+	"github.com/transferwise/amazon-vpc-cni-k8s/rpc/mocks"
 	"google.golang.org/grpc"
 )
 

--- a/plugins/routed-eni/driver/driver.go
+++ b/plugins/routed-eni/driver/driver.go
@@ -24,9 +24,9 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipwrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/ipwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/nswrapper"
 )
 
 const (

--- a/plugins/routed-eni/driver/driver_test.go
+++ b/plugins/routed-eni/driver/driver_test.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/cninswrapper/mock_ns"
-	mocks_ip "github.com/aws/amazon-vpc-cni-k8s/pkg/ipwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mock_netlink"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/cninswrapper/mock_ns"
+	mocks_ip "github.com/transferwise/amazon-vpc-cni-k8s/pkg/ipwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mock_netlink"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/nswrapper/mocks"
 )
 
 const (

--- a/rpc/mocks/rpc_mocks.go
+++ b/rpc/mocks/rpc_mocks.go
@@ -21,7 +21,7 @@ import (
 	context "golang.org/x/net/context"
 	reflect "reflect"
 
-	rpc "github.com/aws/amazon-vpc-cni-k8s/rpc"
+	rpc "github.com/transferwise/amazon-vpc-cni-k8s/rpc"
 	gomock "github.com/golang/mock/gomock"
 	grpc "google.golang.org/grpc"
 )

--- a/verify-aws.go
+++ b/verify-aws.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/logger"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/awsutils"
 
 	log "github.com/cihub/seelog"
 	"math/rand"

--- a/verify-network.go
+++ b/verify-network.go
@@ -15,8 +15,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
-	"github.com/aws/amazon-vpc-cni-k8s/plugins/routed-eni/driver"
+	"github.com/transferwise/amazon-vpc-cni-k8s/pkg/networkutils"
+	"github.com/transferwise/amazon-vpc-cni-k8s/plugins/routed-eni/driver"
 	"net"
 )
 


### PR DESCRIPTION
Please don't squash, the 6a5885f commit is only needed for the fork but not upstream.